### PR TITLE
Adding support for nested InputObjectType and type subclasses

### DIFF
--- a/pydantic2graphene/converter.py
+++ b/pydantic2graphene/converter.py
@@ -119,15 +119,6 @@ class ToGraphene:
                     pydantic_field.name,
                 )
 
-        field = fields.get_grapehene_field_by_type(type_)
-        if field:
-            return field
-
-        if fields.is_field_not_allowed_type(type_):
-            raise errors.InvalidListType(
-                "Lists must be type, e.g typing.List[int]"
-            )
-
         if fields.is_enum_type(type_):
             cache_key, cached_obj = self._get_from_cache(type_, graphene.Enum)
             if cached_obj:
@@ -138,7 +129,17 @@ class ToGraphene:
             return graphene_enum
 
         if fields.is_pydantic_base_model(type_):
-            return ToGraphene(type_).convert()
+            obj_type = self.graphene_type if self.graphene_type == graphene.InputObjectType else graphene.ObjectType
+            return ToGraphene(type_, obj_type).convert()
+
+        field = fields.get_grapehene_field_by_type(type_)
+        if field:
+            return field
+
+        if fields.is_field_not_allowed_type(type_):
+            raise errors.InvalidListType(
+                "Lists must be type, e.g typing.List[int]"
+            )
 
         outer_type_ = getattr(pydantic_field, "outer_type_", None)
         if outer_type_:

--- a/pydantic2graphene/fields.py
+++ b/pydantic2graphene/fields.py
@@ -145,12 +145,6 @@ _ENUM_TYPE = (
 )
 
 
-def _extract_pydantic_base_type(type_):
-    for super_class in type_.mro():
-        if "pydantic.types." in repr(super_class):
-            yield super_class
-
-
 def get_grapehene_field_by_type(type_):
     mapping = _get_type_mapping()
 
@@ -158,7 +152,7 @@ def get_grapehene_field_by_type(type_):
         return mapping[type_]
 
     if inspect.isclass(type_):
-        for pydantic_type in _extract_pydantic_base_type(type_):
+        for pydantic_type in type_.mro():
             if pydantic_type in mapping:
                 return mapping[pydantic_type]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,25 +4,9 @@ import pytest
 import graphene
 
 
-def _get_type_sdl(obj):
-    sdl = str(graphene.Schema(query=obj))
-    return sdl.split("}", 1)[1].strip()
 
-
-def _get_input_sdl(obj):
-    class Query(graphene.ObjectType):
-        foo = graphene.String(node=obj())
-
-    sdl = str(graphene.Schema(query=Query))
-    return sdl.split("}", 1)[1].split("type")[0].strip()
-
-
-def _get_interface_sdl(obj):
-    class Query(graphene.ObjectType):
-        class Meta:
-            interfaces = (obj,)
-
-    sdl = str(graphene.Schema(query=Query))
+def _get_object_type_sdl(obj):
+    sdl = str(graphene.Schema(types=[obj]))
     return sdl.split("}", 1)[1].strip()
 
 
@@ -34,14 +18,8 @@ def obj_to_sdl(
     if isinstance(obj, str):
         return obj
 
-    if issubclass(obj, graphene.ObjectType):
-        return _get_type_sdl(obj)
-
-    if issubclass(obj, graphene.InputObjectType):
-        return _get_input_sdl(obj)
-
-    if issubclass(obj, graphene.Interface):
-        return _get_interface_sdl(obj)
+    if issubclass(obj, (graphene.ObjectType, graphene.InputObjectType, graphene.Interface)):
+        return _get_object_type_sdl(obj)
 
     raise ValueError("Invalid Schema Definition Language (SDL) type")
 

--- a/tests/converter_helper/test_complex_conversions.py
+++ b/tests/converter_helper/test_complex_conversions.py
@@ -49,6 +49,54 @@ class TestConvertingComplexModels:
         """
         assert normalize_sdl(value) == normalize_sdl(expected_value)
 
+    def test_returns_input_object_type_schema(self, normalize_sdl):
+        value = pydantic2graphene.to_graphene(Human, graphene.InputObjectType)
+        expected_value = """
+            scalar DateTime
+
+            input HumanInputGql {
+                name: String!
+                birthDate: DateTime!
+                pets: [PetInputGql] = []
+            }
+
+            input PetInputGql {
+                name: String!
+                specie: SpecieEnum!
+            }
+
+            enum SpecieEnum {
+                DOG
+                CAT
+                OTHER
+            }
+        """
+        assert normalize_sdl(value) == normalize_sdl(expected_value)
+
+    def test_returns_interface_object_type_schema(self, normalize_sdl):
+        value = pydantic2graphene.to_graphene(Human, graphene.Interface)
+        expected_value = """
+            scalar DateTime
+
+            interface HumanInterfaceGql {
+                name: String!
+                birthDate: DateTime!
+                pets: [PetGql]
+            }
+
+            type PetGql {
+                name: String!
+                specie: SpecieEnum!
+            }
+
+            enum SpecieEnum {
+                DOG
+                CAT
+                OTHER
+            }
+        """
+        assert normalize_sdl(value) == normalize_sdl(expected_value)
+
     def test_create_query_schema(self, normalize_sdl):
         HumanGql = pydantic2graphene.to_graphene(Human)
         PetGql = pydantic2graphene.to_graphene(Pet)

--- a/tests/fields/test_boolean.py
+++ b/tests/fields/test_boolean.py
@@ -41,11 +41,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field2: Boolean
             field3: Boolean
         }
-        type Query implements MyModelInterfaceGql {
-            field1: Boolean!
-            field2: Boolean
-            field3: Boolean
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -476,11 +476,16 @@ class TestTypeMappingPydantic2Graphene:
         """
         assert normalize_sdl(value) == normalize_sdl(expected_value)
 
-    def test_pydantic_stricturl_field(self):
-        with pytest.raises(pydantic2graphene.FieldNotSupported):
-            pydantic2graphene.to_graphene(
-                to_pydantic_class(pydantic.stricturl())
-            )
+    def test_pydantic_stricturl_field(self, normalize_sdl):
+        value = pydantic2graphene.to_graphene(
+            to_pydantic_class(pydantic.stricturl())
+        )
+        expected_value = """
+            type FakeGql {
+                field: String!
+            }
+        """
+        assert normalize_sdl(value) == normalize_sdl(expected_value)
 
     def test_pydantic_uuid1_field(self, normalize_sdl):
         value = pydantic2graphene.to_graphene(
@@ -748,4 +753,25 @@ class TestTypeMappingPydantic2Graphene:
                 field: String!
             }
         """
+        assert normalize_sdl(value) == normalize_sdl(expected_value)
+
+    @pytest.mark.parametrize('base_type, graphene_type_name', (
+        (str, 'String'),
+        (int, 'Int'),
+        (float, 'Float'),
+        (decimal.Decimal, 'Float'),
+        (bytes, 'String'),
+    ))
+    def test_subclass_of_supported_fields(self, normalize_sdl, base_type, graphene_type_name):
+        class MyCustomSubclass(base_type):
+            pass
+
+        value = pydantic2graphene.to_graphene(
+            to_pydantic_class(MyCustomSubclass)
+        )
+        expected_value = """
+            type FakeGql {
+                field: %s!
+            }
+        """ % graphene_type_name
         assert normalize_sdl(value) == normalize_sdl(expected_value)

--- a/tests/fields/test_float.py
+++ b/tests/fields/test_float.py
@@ -37,10 +37,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field1: Float!
             field2: Float
         }
-        type Query implements MyModelInterfaceGql {
-            field1: Float!
-            field2: Float
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 

--- a/tests/fields/test_int.py
+++ b/tests/fields/test_int.py
@@ -37,10 +37,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field1: Int!
             field2: Int
         }
-        type Query implements MyModelInterfaceGql {
-            field1: Int!
-            field2: Int
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 

--- a/tests/fields/test_string.py
+++ b/tests/fields/test_string.py
@@ -37,10 +37,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field1: String!
             field2: String
         }
-        type Query implements MyModelInterfaceGql {
-            field1: String!
-            field2: String
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 


### PR DESCRIPTION
Howdy! Thanks for this library and its neat API.

While playing with it in my project I've stumbled upon few gotchas and after debugging session, I've found out that instead of opening issue I can fix this by myself and create this PR.

#### Type subclasses
Contents of `get_grapehene_field_by_type()` was checking only for direct types or for pydantic types in class MRO, which fails for cases like `class MyStr(str):...`. Removing pydantic type requirements gives us ability to handle more cases, but we need postpone these checks as tests for specific enums will fail. Few additional test cases and we are ready to go!

#### Nested InputObjectType
While we want to generate input object from pydantic model, we can have case, where model contains nested model. That nested model was created with defaults - as ObjectType - which was failing requirements to have all objects as inputs, even for nested objects. Forwarding input type while handling nested pydantic models does the job, with proper caching. Unfortunately it turns out that `normalize_sdl` had problem with inputs normalization, as enums definition ends up after "type" cut off in `_get_input_sdl()`. I'm using different syntax for schema extraction, which does not polluting outputs with unnecessary mocked stuff and produces same results regardless of provided types. In result we can use same function for all graphene object types. Also, few tests needed to be fixed, as we no longer use mocked query objects for schema extraction.

And pretty much that's all. Hope you like it! :)