### PR TITLE
Adding support for nested InputObjectType and type subclasses

### DIFF
--- a/pydantic2graphene/converter.py
+++ b/pydantic2graphene/converter.py
@@ -119,15 +119,6 @@ class ToGraphene:
                     pydantic_field.name,
                 )
 
-        field = fields.get_grapehene_field_by_type(type_)
-        if field:
-            return field
-
-        if fields.is_field_not_allowed_type(type_):
-            raise errors.InvalidListType(
-                "Lists must be type, e.g typing.List[int]"
-            )
-
         if fields.is_enum_type(type_):
             cache_key, cached_obj = self._get_from_cache(type_, graphene.Enum)
             if cached_obj:
@@ -138,7 +129,21 @@ class ToGraphene:
             return graphene_enum
 
         if fields.is_pydantic_base_model(type_):
-            return ToGraphene(type_).convert()
+            if self.graphene_type == graphene.InputObjectType:
+                obj_type = self.graphene_type
+            else:
+                obj_type = graphene.ObjectType
+
+            return ToGraphene(type_, obj_type).convert()
+
+        field = fields.get_grapehene_field_by_type(type_)
+        if field:
+            return field
+
+        if fields.is_field_not_allowed_type(type_):
+            raise errors.InvalidListType(
+                "Lists must be type, e.g typing.List[int]"
+            )
 
         outer_type_ = getattr(pydantic_field, "outer_type_", None)
         if outer_type_:

--- a/pydantic2graphene/fields.py
+++ b/pydantic2graphene/fields.py
@@ -145,12 +145,6 @@ _ENUM_TYPE = (
 )
 
 
-def _extract_pydantic_base_type(type_):
-    for super_class in type_.mro():
-        if "pydantic.types." in repr(super_class):
-            yield super_class
-
-
 def get_grapehene_field_by_type(type_):
     mapping = _get_type_mapping()
 
@@ -158,7 +152,7 @@ def get_grapehene_field_by_type(type_):
         return mapping[type_]
 
     if inspect.isclass(type_):
-        for pydantic_type in _extract_pydantic_base_type(type_):
+        for pydantic_type in type_.mro():
             if pydantic_type in mapping:
                 return mapping[pydantic_type]
 

--- a/pydantic2graphene/fields.py
+++ b/pydantic2graphene/fields.py
@@ -10,9 +10,27 @@ import graphene
 import graphene.types.datetime
 import pydantic.fields
 
-_NOT_SUPPORTED_SHAPES = {
-    pydantic.fields.SHAPE_MAPPING,
-}
+
+_NOT_SUPPORTED_SHAPES = None
+
+
+def _get_not_supported_shapes():
+    global _NOT_SUPPORTED_SHAPES
+    if _NOT_SUPPORTED_SHAPES:
+        return _NOT_SUPPORTED_SHAPES
+
+    _NOT_SUPPORTED_SHAPES = {
+        pydantic.fields.SHAPE_MAPPING,
+    }
+
+    # pydantic pydantic<=1.8 does not have SHAPE_DICT and SHAPE_DEFAULTDICT
+    try:
+        _NOT_SUPPORTED_SHAPES.add(pydantic.fields.SHAPE_DICT)
+        _NOT_SUPPORTED_SHAPES.add(pydantic.fields.SHAPE_DEFAULTDICT)
+    except AttributeError:
+        pass
+
+    return _NOT_SUPPORTED_SHAPES
 
 
 _LIST_SHAPES = None
@@ -170,7 +188,7 @@ def is_list_shape(shape) -> bool:
 
 
 def is_not_supported_shape(shape) -> bool:
-    return shape in _NOT_SUPPORTED_SHAPES
+    return shape in _get_not_supported_shapes()
 
 
 def is_pydantic_base_model(type_) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import collections
 import typing
 import pytest
 import graphene
+import re
 
 
 def _get_type_sdl(obj):
@@ -14,7 +15,7 @@ def _get_input_sdl(obj):
         foo = graphene.String(node=obj())
 
     sdl = str(graphene.Schema(query=Query))
-    return sdl.split("}", 1)[1].split("type")[0].strip()
+    return re.sub('type Query[^}]*}', '', sdl.split("}", 1)[1].strip())
 
 
 def _get_interface_sdl(obj):
@@ -23,7 +24,7 @@ def _get_interface_sdl(obj):
             interfaces = (obj,)
 
     sdl = str(graphene.Schema(query=Query))
-    return sdl.split("}", 1)[1].strip()
+    return re.sub('type Query[^}]*}', '', sdl.split("}", 1)[1].strip())
 
 
 def obj_to_sdl(

--- a/tests/converter_helper/test_complex_conversions.py
+++ b/tests/converter_helper/test_complex_conversions.py
@@ -49,6 +49,54 @@ class TestConvertingComplexModels:
         """
         assert normalize_sdl(value) == normalize_sdl(expected_value)
 
+    def test_returns_input_object_type_schema(self, normalize_sdl):
+        value = pydantic2graphene.to_graphene(Human, graphene.InputObjectType)
+        expected_value = """
+            scalar DateTime
+
+            input HumanInputGql {
+                name: String!
+                birthDate: DateTime!
+                pets: [PetInputGql] = []
+            }
+
+            input PetInputGql {
+                name: String!
+                specie: SpecieEnum!
+            }
+
+            enum SpecieEnum {
+                DOG
+                CAT
+                OTHER
+            }
+        """
+        assert normalize_sdl(value) == normalize_sdl(expected_value)
+
+    def test_returns_interface_object_type_schema(self, normalize_sdl):
+        value = pydantic2graphene.to_graphene(Human, graphene.Interface)
+        expected_value = """
+            scalar DateTime
+
+            interface HumanInterfaceGql {
+                name: String!
+                birthDate: DateTime!
+                pets: [PetGql]
+            }
+
+            type PetGql {
+                name: String!
+                specie: SpecieEnum!
+            }
+
+            enum SpecieEnum {
+                DOG
+                CAT
+                OTHER
+            }
+        """
+        assert normalize_sdl(value) == normalize_sdl(expected_value)
+
     def test_create_query_schema(self, normalize_sdl):
         HumanGql = pydantic2graphene.to_graphene(Human)
         PetGql = pydantic2graphene.to_graphene(Pet)

--- a/tests/fields/test_boolean.py
+++ b/tests/fields/test_boolean.py
@@ -41,11 +41,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field2: Boolean
             field3: Boolean
         }
-        type Query implements MyModelInterfaceGql {
-            field1: Boolean!
-            field2: Boolean
-            field3: Boolean
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -146,6 +146,12 @@ class TestTypeMappingPydantic2Graphene:
                 to_pydantic_class(typing.Dict[str, str])
             )
 
+    def test_typing_defaultdict_field(self):
+        with pytest.raises(pydantic2graphene.FieldNotSupported):
+            pydantic2graphene.to_graphene(
+                to_pydantic_class(typing.DefaultDict[str, str])
+            )
+
     def test_typing_set_field(self, normalize_sdl):
         value = pydantic2graphene.to_graphene(
             to_pydantic_class(typing.Set[str])

--- a/tests/fields/test_float.py
+++ b/tests/fields/test_float.py
@@ -37,10 +37,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field1: Float!
             field2: Float
         }
-        type Query implements MyModelInterfaceGql {
-            field1: Float!
-            field2: Float
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 

--- a/tests/fields/test_int.py
+++ b/tests/fields/test_int.py
@@ -37,10 +37,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field1: Int!
             field2: Int
         }
-        type Query implements MyModelInterfaceGql {
-            field1: Int!
-            field2: Int
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 

--- a/tests/fields/test_string.py
+++ b/tests/fields/test_string.py
@@ -37,10 +37,6 @@ def test_schema_interface_declaration(normalize_sdl):
             field1: String!
             field2: String
         }
-        type Query implements MyModelInterfaceGql {
-            field1: String!
-            field2: String
-        }
     """
     assert normalize_sdl(value) == normalize_sdl(expected_value)
 


### PR DESCRIPTION
Follow up for #25, but this time all tests in GH Actions are passing. Also pydantic recently had some internal changes that results in fails with blacklisting Dicts, I fixed this too.